### PR TITLE
build with rkt-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 rkt-sidekick
 vendor/
+bin/
+acbuild

--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ That provides the more [rkt]-like approach to [sidekick] model implementation wh
 ## Images
 Signed `ACI`s for `linux-arm64` are available at `monder.cc/rkt-sidekick` with versions matching git tags.
 
+## Prerequisites
+
+acbuild
+
+## Dependencies
+
+see `install-deps.sh`
+
+## Build
+
+```
+./build-aci.sh
+```
+
+## Build with rkt
+
+```
+./build-rkt
+```
+
 ## Usage
 
 ```

--- a/build-aci.sh
+++ b/build-aci.sh
@@ -5,14 +5,14 @@ export GOOS=linux
 export GOARCH=amd64
 export VERSION=v0.0.2
 
-go build -ldflags '-extldflags "-static"'
+go build -o bin/rkt-sidekick -ldflags '-extldflags "-static"'
 acbuild begin
 acbuild set-name monder.cc/rkt-sidekick
-acbuild copy rkt-sidekick /bin/rkt-sidekick
+acbuild copy bin/rkt-sidekick /bin/rkt-sidekick
 acbuild set-exec /bin/rkt-sidekick
 acbuild label add version $VERSION
 acbuild label add arch $GOARCH
 acbuild label add os $GOOS
 acbuild annotation add authors "Aleksejs Sinicins <monder@monder.cc>"
-acbuild write rkt-sidekick-${VERSION}-${GOOS}-${GOARCH}.aci --overwrite
+acbuild write bin/rkt-sidekick-${VERSION}-${GOOS}-${GOARCH}.aci --overwrite
 acbuild end

--- a/build-rkt
+++ b/build-rkt
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+export SRC_DIR=`pwd`
+
+sudo rkt run \
+    --volume src-dir,kind=host,source=${SRC_DIR} \
+    --volume build-dir,kind=host,source=${SRC_DIR} \
+    --interactive \
+    coreos.com/rkt/builder:1.0.1 \
+    --exec /bin/sh \
+	-- -c 'export PATH=$PATH:/opt/rkt && ./install-deps.sh && ./build-aci.sh'

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+go get -u github.com/coreos/etcd/client
+go get -u github.com/spf13/pflag
+go get -u golang.org/x/net/context


### PR DESCRIPTION
I'm developing 100% in coreos without using the coreos toolbox. This means builds must be 100% isolated by default and so the next step for CI is just wiring.
